### PR TITLE
ceph-iscsi-ansible.spec: fix rpmlint warnings

### DIFF
--- a/packages/ceph-iscsi-ansible.spec
+++ b/packages/ceph-iscsi-ansible.spec
@@ -21,8 +21,7 @@ To use the playbook you must ensure that the gateway nodes are the ceph-iscsi-co
 %prep
 %setup -q 
 
-#%build
-#
+%build
 
 %install
 mkdir -p %{buildroot}%{_datarootdir}/ceph-ansible


### PR DESCRIPTION
This fixes the following warnings from rpmlint:

```
ceph-iscsi-ansible.spec:24: W: macro-in-comment %build
ceph-iscsi-ansible.spec: W: no-%build-section
```
